### PR TITLE
fix: update routing for drivers and adjust stop ride button placement

### DIFF
--- a/web/src/app/core/components/dev-login-helper.component.ts
+++ b/web/src/app/core/components/dev-login-helper.component.ts
@@ -145,7 +145,7 @@ export class DevLoginHelperComponent {
       next: (user) => {
         // Navigate based on role
         if (user.role === 'driver') {
-          this.router.navigate(['/driver-history']);
+          this.router.navigate(['/driver-home']);
         } else if (user.role === 'passenger') {
           this.router.navigate(['/passenger-home']);
         } else if (user.role === 'admin') {

--- a/web/src/app/features/auth/login/login.component.ts
+++ b/web/src/app/features/auth/login/login.component.ts
@@ -32,7 +32,7 @@ export class LoginComponent {
           if (user.role === 'passenger') {
             this.router.navigate(['/passenger-home']);
           } else if (user.role === 'driver') {
-            this.router.navigate(['/driver-history']);
+            this.router.navigate(['/driver-home']);
           } else if (user.role === 'admin') {
             this.router.navigate(['/admin/add-driver']);
           } else {

--- a/web/src/app/features/driver/driver-home/driver-home.component.html
+++ b/web/src/app/features/driver/driver-home/driver-home.component.html
@@ -156,21 +156,21 @@
           </button>
         }
 
-        @if (canCompleteRide() && stopRequested()) {
-          <button
-            (click)="stopRideEarly()"
-            class="btn btn-stop-early"
-            [disabled]="actionInProgress()">
-            {{ actionInProgress() ? 'Stopping...' : 'Stop Ride Early' }}
-          </button>
-        }
-
         @if (canCompleteRide() && !stopRequested()) {
           <button
             (click)="completeRide()"
             class="btn btn-complete"
             [disabled]="actionInProgress()">
             {{ actionInProgress() ? 'Completing...' : 'Complete Ride' }}
+          </button>
+        }
+
+        @if (canCompleteRide()) {
+          <button
+            (click)="stopRideEarly()"
+            class="btn btn-stop-early"
+            [disabled]="actionInProgress()">
+            {{ actionInProgress() ? 'Stopping...' : 'Stop Ride Early' }}
           </button>
         }
 


### PR DESCRIPTION
- Update driver navigation to route to `/driver-home` instead of `/driver-history`.
- Fix placement of "Stop Ride Early" button by consolidating logic in `driver-home.component.html`.