### PR TITLE
feat(admin-services): add ride detail and history retrieval for admin

### DIFF
--- a/backend/blackcar-api/src/main/java/com/pekara/dto/response/AdminRideDetailResponse.java
+++ b/backend/blackcar-api/src/main/java/com/pekara/dto/response/AdminRideDetailResponse.java
@@ -1,0 +1,132 @@
+package com.pekara.dto.response;
+
+import com.pekara.dto.common.LocationPointDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Response DTO for detailed ride information including route coordinates,
+ * ratings, and inconsistency reports. Used for admin detailed view with map.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminRideDetailResponse {
+
+    private Long id;
+    private String status;
+
+    // Dates
+    private LocalDateTime createdAt;
+    private LocalDateTime scheduledAt;
+    private LocalDateTime startedAt;
+    private LocalDateTime completedAt;
+
+    // Locations
+    private String pickupAddress;
+    private String dropoffAddress;
+    private LocationPointDto pickup;
+    private LocationPointDto dropoff;
+    private List<LocationPointDto> stops;
+
+    // Route for map display
+    private String routeCoordinates;
+
+    // Cancellation info
+    private Boolean cancelled;
+    private String cancelledBy;
+    private String cancellationReason;
+    private LocalDateTime cancelledAt;
+
+    // Pricing
+    private BigDecimal price;
+    private Double distanceKm;
+    private Integer estimatedDurationMinutes;
+
+    // Panic info
+    private Boolean panicActivated;
+    private String panickedBy;
+
+    // Vehicle info
+    private String vehicleType;
+    private Boolean babyTransport;
+    private Boolean petTransport;
+
+    // Driver details
+    private DriverDetailInfo driver;
+
+    // Passengers details
+    private List<PassengerDetailInfo> passengers;
+
+    // Ratings
+    private List<RideRatingInfo> ratings;
+
+    // Inconsistency reports
+    private List<InconsistencyReportInfo> inconsistencyReports;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DriverDetailInfo {
+        private Long id;
+        private String firstName;
+        private String lastName;
+        private String email;
+        private String phoneNumber;
+        private String profilePicture;
+        private String licenseNumber;
+        private String vehicleModel;
+        private String licensePlate;
+        private Double averageRating;
+        private Integer totalRides;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PassengerDetailInfo {
+        private Long id;
+        private String firstName;
+        private String lastName;
+        private String email;
+        private String phoneNumber;
+        private String profilePicture;
+        private Integer totalRides;
+        private Double averageRating;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RideRatingInfo {
+        private Long id;
+        private Long passengerId;
+        private String passengerName;
+        private Integer vehicleRating;
+        private Integer driverRating;
+        private String comment;
+        private LocalDateTime ratedAt;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InconsistencyReportInfo {
+        private Long id;
+        private Long reportedByUserId;
+        private String reportedByName;
+        private String description;
+        private LocalDateTime reportedAt;
+    }
+}

--- a/backend/blackcar-api/src/main/java/com/pekara/dto/response/AdminRideHistoryResponse.java
+++ b/backend/blackcar-api/src/main/java/com/pekara/dto/response/AdminRideHistoryResponse.java
@@ -1,0 +1,85 @@
+package com.pekara.dto.response;
+
+import com.pekara.dto.common.LocationPointDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Response DTO for admin ride history list.
+ * Contains all ride information needed for the history overview.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminRideHistoryResponse {
+
+    private Long id;
+    private String status;
+
+    // Dates
+    private LocalDateTime createdAt;
+    private LocalDateTime scheduledAt;
+    private LocalDateTime startedAt;
+    private LocalDateTime completedAt;
+
+    // Locations
+    private String pickupAddress;
+    private String dropoffAddress;
+    private LocationPointDto pickup;
+    private LocationPointDto dropoff;
+    private List<LocationPointDto> stops;
+
+    // Cancellation info
+    private Boolean cancelled;
+    private String cancelledBy;
+    private String cancellationReason;
+    private LocalDateTime cancelledAt;
+
+    // Pricing
+    private BigDecimal price;
+    private Double distanceKm;
+    private Integer estimatedDurationMinutes;
+
+    // Panic info
+    private Boolean panicActivated;
+    private String panickedBy;
+
+    // Vehicle info
+    private String vehicleType;
+    private Boolean babyTransport;
+    private Boolean petTransport;
+
+    // Participants
+    private DriverBasicInfo driver;
+    private List<PassengerBasicInfo> passengers;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DriverBasicInfo {
+        private Long id;
+        private String firstName;
+        private String lastName;
+        private String email;
+        private String phoneNumber;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PassengerBasicInfo {
+        private Long id;
+        private String firstName;
+        private String lastName;
+        private String email;
+    }
+}

--- a/backend/blackcar-api/src/main/java/com/pekara/service/AdminService.java
+++ b/backend/blackcar-api/src/main/java/com/pekara/service/AdminService.java
@@ -1,0 +1,14 @@
+package com.pekara.service;
+
+import com.pekara.dto.response.AdminRideDetailResponse;
+import com.pekara.dto.response.AdminRideHistoryResponse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface AdminService {
+
+    List<AdminRideHistoryResponse> getAllRidesHistory(LocalDateTime startDate, LocalDateTime endDate);
+
+    AdminRideDetailResponse getRideDetail(Long rideId);
+}

--- a/backend/blackcar-core/src/main/java/com/pekara/model/InconsistencyReport.java
+++ b/backend/blackcar-core/src/main/java/com/pekara/model/InconsistencyReport.java
@@ -1,0 +1,45 @@
+package com.pekara.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Entity representing an inconsistency report filed by a passenger during a ride.
+ * Used to track driving issues or problems reported by passengers.
+ */
+@Entity
+@Table(name = "inconsistency_reports")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InconsistencyReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "ride_id", nullable = false)
+    private Ride ride;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reported_by_user_id", nullable = false)
+    private User reportedBy;
+
+    @Column(name = "description", nullable = false, length = 1000)
+    private String description;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/backend/blackcar-core/src/main/java/com/pekara/repository/InconsistencyReportRepository.java
+++ b/backend/blackcar-core/src/main/java/com/pekara/repository/InconsistencyReportRepository.java
@@ -1,0 +1,16 @@
+package com.pekara.repository;
+
+import com.pekara.model.InconsistencyReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface InconsistencyReportRepository extends JpaRepository<InconsistencyReport, Long> {
+
+    @Query("SELECT ir FROM InconsistencyReport ir WHERE ir.ride.id = :rideId ORDER BY ir.createdAt DESC")
+    List<InconsistencyReport> findAllByRideId(@Param("rideId") Long rideId);
+}

--- a/backend/blackcar-core/src/main/java/com/pekara/repository/RideRatingRepository.java
+++ b/backend/blackcar-core/src/main/java/com/pekara/repository/RideRatingRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,6 +14,9 @@ public interface RideRatingRepository extends JpaRepository<RideRating, Long> {
 
     @Query("SELECT rr FROM RideRating rr WHERE rr.ride.id = :rideId")
     Optional<RideRating> findByRideId(@Param("rideId") Long rideId);
+
+    @Query("SELECT rr FROM RideRating rr WHERE rr.ride.id = :rideId")
+    List<RideRating> findAllByRideId(@Param("rideId") Long rideId);
 
     @Query("SELECT rr FROM RideRating rr WHERE rr.ride.id = :rideId AND rr.passenger.id = :passengerId")
     Optional<RideRating> findByRideIdAndPassengerId(@Param("rideId") Long rideId, @Param("passengerId") Long passengerId);

--- a/backend/blackcar-core/src/main/java/com/pekara/repository/RideRepository.java
+++ b/backend/blackcar-core/src/main/java/com/pekara/repository/RideRepository.java
@@ -47,4 +47,12 @@ public interface RideRepository extends JpaRepository<Ride, Long> {
 
     @Query("SELECT r FROM Ride r WHERE r.panicActivated = true AND r.status IN :statuses ORDER BY r.updatedAt DESC")
     List<Ride> findActivePanicRides(@Param("statuses") List<RideStatus> statuses);
+
+    /**
+     * Find all rides within date range for admin history view.
+     * Sorted by createdAt from newest to oldest.
+     */
+    @Query("SELECT r FROM Ride r WHERE r.createdAt BETWEEN :startDate AND :endDate ORDER BY r.createdAt DESC")
+    List<Ride> findAllRidesHistory(@Param("startDate") LocalDateTime startDate,
+                                   @Param("endDate") LocalDateTime endDate);
 }

--- a/backend/blackcar-core/src/main/java/com/pekara/service/AdminServiceImpl.java
+++ b/backend/blackcar-core/src/main/java/com/pekara/service/AdminServiceImpl.java
@@ -1,0 +1,278 @@
+package com.pekara.service;
+
+import com.pekara.dto.common.LocationPointDto;
+import com.pekara.dto.response.AdminRideDetailResponse;
+import com.pekara.dto.response.AdminRideHistoryResponse;
+import com.pekara.model.*;
+import com.pekara.repository.InconsistencyReportRepository;
+import com.pekara.repository.RideRatingRepository;
+import com.pekara.repository.RideRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminServiceImpl implements AdminService {
+
+    private final RideRepository rideRepository;
+    private final RideRatingRepository rideRatingRepository;
+    private final InconsistencyReportRepository inconsistencyReportRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AdminRideHistoryResponse> getAllRidesHistory(LocalDateTime startDate, LocalDateTime endDate) {
+        log.debug("Fetching all rides history from {} to {}", startDate, endDate);
+        
+        List<Ride> rides = rideRepository.findAllRidesHistory(startDate, endDate);
+        
+        return rides.stream()
+                .map(this::mapToHistoryResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AdminRideDetailResponse getRideDetail(Long rideId) {
+        log.debug("Fetching ride detail for rideId: {}", rideId);
+        
+        Ride ride = rideRepository.findById(rideId)
+                .orElseThrow(() -> new IllegalArgumentException("Ride not found: " + rideId));
+        
+        List<RideRating> ratings = rideRatingRepository.findAllByRideId(rideId);
+        List<InconsistencyReport> reports = inconsistencyReportRepository.findAllByRideId(rideId);
+        
+        return mapToDetailResponse(ride, ratings, reports);
+    }
+
+    private AdminRideHistoryResponse mapToHistoryResponse(Ride ride) {
+        // Get pickup and dropoff from stops (first and last)
+        List<RideStop> stops = ride.getStops();
+        RideStop pickup = stops.isEmpty() ? null : stops.get(0);
+        RideStop dropoff = stops.isEmpty() ? null : stops.get(stops.size() - 1);
+        
+        // Get intermediate stops (excluding first and last)
+        List<LocationPointDto> intermediateStops = new ArrayList<>();
+        if (stops.size() > 2) {
+            for (int i = 1; i < stops.size() - 1; i++) {
+                RideStop stop = stops.get(i);
+                intermediateStops.add(LocationPointDto.builder()
+                        .latitude(stop.getLatitude())
+                        .longitude(stop.getLongitude())
+                        .address(stop.getAddress())
+                        .build());
+            }
+        }
+
+        return AdminRideHistoryResponse.builder()
+                .id(ride.getId())
+                .status(ride.getStatus().name())
+                // Dates
+                .createdAt(ride.getCreatedAt())
+                .scheduledAt(ride.getScheduledAt())
+                .startedAt(ride.getStartedAt())
+                .completedAt(ride.getCompletedAt())
+                // Locations
+                .pickupAddress(pickup != null ? pickup.getAddress() : null)
+                .dropoffAddress(dropoff != null ? dropoff.getAddress() : null)
+                .pickup(pickup != null ? LocationPointDto.builder()
+                        .latitude(pickup.getLatitude())
+                        .longitude(pickup.getLongitude())
+                        .address(pickup.getAddress())
+                        .build() : null)
+                .dropoff(dropoff != null ? LocationPointDto.builder()
+                        .latitude(dropoff.getLatitude())
+                        .longitude(dropoff.getLongitude())
+                        .address(dropoff.getAddress())
+                        .build() : null)
+                .stops(intermediateStops)
+                // Cancellation
+                .cancelled(ride.getCancelledBy() != null)
+                .cancelledBy(ride.getCancelledBy())
+                .cancellationReason(ride.getCancellationReason())
+                .cancelledAt(ride.getCancelledAt())
+                // Pricing
+                .price(ride.getEstimatedPrice())
+                .distanceKm(ride.getDistanceKm())
+                .estimatedDurationMinutes(ride.getEstimatedDurationMinutes())
+                // Panic
+                .panicActivated(ride.getPanicActivated())
+                .panickedBy(ride.getPanickedBy())
+                // Vehicle
+                .vehicleType(ride.getVehicleType())
+                .babyTransport(ride.getBabyTransport())
+                .petTransport(ride.getPetTransport())
+                // Participants
+                .driver(mapDriverBasicInfo(ride.getDriver()))
+                .passengers(mapPassengersBasicInfo(ride.getPassengers()))
+                .build();
+    }
+
+    private AdminRideDetailResponse mapToDetailResponse(Ride ride, List<RideRating> ratings, List<InconsistencyReport> reports) {
+        // Get pickup and dropoff from stops (first and last)
+        List<RideStop> stops = ride.getStops();
+        RideStop pickup = stops.isEmpty() ? null : stops.get(0);
+        RideStop dropoff = stops.isEmpty() ? null : stops.get(stops.size() - 1);
+        
+        // Get intermediate stops (excluding first and last)
+        List<LocationPointDto> intermediateStops = new ArrayList<>();
+        if (stops.size() > 2) {
+            for (int i = 1; i < stops.size() - 1; i++) {
+                RideStop stop = stops.get(i);
+                intermediateStops.add(LocationPointDto.builder()
+                        .latitude(stop.getLatitude())
+                        .longitude(stop.getLongitude())
+                        .address(stop.getAddress())
+                        .build());
+            }
+        }
+
+        return AdminRideDetailResponse.builder()
+                .id(ride.getId())
+                .status(ride.getStatus().name())
+                // Dates
+                .createdAt(ride.getCreatedAt())
+                .scheduledAt(ride.getScheduledAt())
+                .startedAt(ride.getStartedAt())
+                .completedAt(ride.getCompletedAt())
+                // Locations
+                .pickupAddress(pickup != null ? pickup.getAddress() : null)
+                .dropoffAddress(dropoff != null ? dropoff.getAddress() : null)
+                .pickup(pickup != null ? LocationPointDto.builder()
+                        .latitude(pickup.getLatitude())
+                        .longitude(pickup.getLongitude())
+                        .address(pickup.getAddress())
+                        .build() : null)
+                .dropoff(dropoff != null ? LocationPointDto.builder()
+                        .latitude(dropoff.getLatitude())
+                        .longitude(dropoff.getLongitude())
+                        .address(dropoff.getAddress())
+                        .build() : null)
+                .stops(intermediateStops)
+                // Route for map
+                .routeCoordinates(ride.getRouteCoordinates())
+                // Cancellation
+                .cancelled(ride.getCancelledBy() != null)
+                .cancelledBy(ride.getCancelledBy())
+                .cancellationReason(ride.getCancellationReason())
+                .cancelledAt(ride.getCancelledAt())
+                // Pricing
+                .price(ride.getEstimatedPrice())
+                .distanceKm(ride.getDistanceKm())
+                .estimatedDurationMinutes(ride.getEstimatedDurationMinutes())
+                // Panic
+                .panicActivated(ride.getPanicActivated())
+                .panickedBy(ride.getPanickedBy())
+                // Vehicle
+                .vehicleType(ride.getVehicleType())
+                .babyTransport(ride.getBabyTransport())
+                .petTransport(ride.getPetTransport())
+                // Driver details
+                .driver(mapDriverDetailInfo(ride.getDriver()))
+                // Passenger details
+                .passengers(mapPassengersDetailInfo(ride.getPassengers()))
+                // Ratings
+                .ratings(mapRatings(ratings))
+                // Inconsistency reports
+                .inconsistencyReports(mapInconsistencyReports(reports))
+                .build();
+    }
+
+    private AdminRideHistoryResponse.DriverBasicInfo mapDriverBasicInfo(Driver driver) {
+        if (driver == null) return null;
+        
+        return AdminRideHistoryResponse.DriverBasicInfo.builder()
+                .id(driver.getId())
+                .firstName(driver.getFirstName())
+                .lastName(driver.getLastName())
+                .email(driver.getEmail())
+                .phoneNumber(driver.getPhoneNumber())
+                .build();
+    }
+
+    private List<AdminRideHistoryResponse.PassengerBasicInfo> mapPassengersBasicInfo(java.util.Set<User> passengers) {
+        if (passengers == null || passengers.isEmpty()) return new ArrayList<>();
+        
+        return passengers.stream()
+                .map(p -> AdminRideHistoryResponse.PassengerBasicInfo.builder()
+                        .id(p.getId())
+                        .firstName(p.getFirstName())
+                        .lastName(p.getLastName())
+                        .email(p.getEmail())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    private AdminRideDetailResponse.DriverDetailInfo mapDriverDetailInfo(Driver driver) {
+        if (driver == null) return null;
+        
+        return AdminRideDetailResponse.DriverDetailInfo.builder()
+                .id(driver.getId())
+                .firstName(driver.getFirstName())
+                .lastName(driver.getLastName())
+                .email(driver.getEmail())
+                .phoneNumber(driver.getPhoneNumber())
+                .profilePicture(driver.getProfilePicture())
+                .licenseNumber(driver.getLicenseNumber())
+                .vehicleModel(driver.getVehicleModel())
+                .licensePlate(driver.getLicensePlate())
+                .averageRating(driver.getAverageRating())
+                .totalRides(driver.getTotalRides())
+                .build();
+    }
+
+    private List<AdminRideDetailResponse.PassengerDetailInfo> mapPassengersDetailInfo(java.util.Set<User> passengers) {
+        if (passengers == null || passengers.isEmpty()) return new ArrayList<>();
+        
+        return passengers.stream()
+                .map(p -> AdminRideDetailResponse.PassengerDetailInfo.builder()
+                        .id(p.getId())
+                        .firstName(p.getFirstName())
+                        .lastName(p.getLastName())
+                        .email(p.getEmail())
+                        .phoneNumber(p.getPhoneNumber())
+                        .profilePicture(p.getProfilePicture())
+                        .totalRides(p.getTotalRides())
+                        .averageRating(p.getAverageRating())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    private List<AdminRideDetailResponse.RideRatingInfo> mapRatings(List<RideRating> ratings) {
+        if (ratings == null || ratings.isEmpty()) return new ArrayList<>();
+        
+        return ratings.stream()
+                .map(r -> AdminRideDetailResponse.RideRatingInfo.builder()
+                        .id(r.getId())
+                        .passengerId(r.getPassenger().getId())
+                        .passengerName(r.getPassenger().getFirstName() + " " + r.getPassenger().getLastName())
+                        .vehicleRating(r.getVehicleRating())
+                        .driverRating(r.getDriverRating())
+                        .comment(r.getComment())
+                        .ratedAt(r.getCreatedAt())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    private List<AdminRideDetailResponse.InconsistencyReportInfo> mapInconsistencyReports(List<InconsistencyReport> reports) {
+        if (reports == null || reports.isEmpty()) return new ArrayList<>();
+        
+        return reports.stream()
+                .map(r -> AdminRideDetailResponse.InconsistencyReportInfo.builder()
+                        .id(r.getId())
+                        .reportedByUserId(r.getReportedBy().getId())
+                        .reportedByName(r.getReportedBy().getFirstName() + " " + r.getReportedBy().getLastName())
+                        .description(r.getDescription())
+                        .reportedAt(r.getCreatedAt())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/blackcar-web/src/main/java/com/pekara/dto/response/WebAdminRideDetailResponse.java
+++ b/backend/blackcar-web/src/main/java/com/pekara/dto/response/WebAdminRideDetailResponse.java
@@ -1,0 +1,132 @@
+package com.pekara.dto.response;
+
+import com.pekara.dto.common.WebLocationPoint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Web response DTO for detailed ride information including route coordinates,
+ * ratings, and inconsistency reports. Used for admin detailed view with map.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WebAdminRideDetailResponse {
+
+    private Long id;
+    private String status;
+
+    // Dates
+    private LocalDateTime createdAt;
+    private LocalDateTime scheduledAt;
+    private LocalDateTime startedAt;
+    private LocalDateTime completedAt;
+
+    // Locations
+    private String pickupAddress;
+    private String dropoffAddress;
+    private WebLocationPoint pickup;
+    private WebLocationPoint dropoff;
+    private List<WebLocationPoint> stops;
+
+    // Route for map display
+    private String routeCoordinates;
+
+    // Cancellation info
+    private Boolean cancelled;
+    private String cancelledBy;
+    private String cancellationReason;
+    private LocalDateTime cancelledAt;
+
+    // Pricing
+    private BigDecimal price;
+    private Double distanceKm;
+    private Integer estimatedDurationMinutes;
+
+    // Panic info
+    private Boolean panicActivated;
+    private String panickedBy;
+
+    // Vehicle info
+    private String vehicleType;
+    private Boolean babyTransport;
+    private Boolean petTransport;
+
+    // Driver details
+    private DriverDetailInfo driver;
+
+    // Passengers details
+    private List<PassengerDetailInfo> passengers;
+
+    // Ratings
+    private List<RideRatingInfo> ratings;
+
+    // Inconsistency reports
+    private List<InconsistencyReportInfo> inconsistencyReports;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DriverDetailInfo {
+        private Long id;
+        private String firstName;
+        private String lastName;
+        private String email;
+        private String phoneNumber;
+        private String profilePicture;
+        private String licenseNumber;
+        private String vehicleModel;
+        private String licensePlate;
+        private Double averageRating;
+        private Integer totalRides;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PassengerDetailInfo {
+        private Long id;
+        private String firstName;
+        private String lastName;
+        private String email;
+        private String phoneNumber;
+        private String profilePicture;
+        private Integer totalRides;
+        private Double averageRating;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RideRatingInfo {
+        private Long id;
+        private Long passengerId;
+        private String passengerName;
+        private Integer vehicleRating;
+        private Integer driverRating;
+        private String comment;
+        private LocalDateTime ratedAt;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InconsistencyReportInfo {
+        private Long id;
+        private Long reportedByUserId;
+        private String reportedByName;
+        private String description;
+        private LocalDateTime reportedAt;
+    }
+}

--- a/backend/blackcar-web/src/main/java/com/pekara/dto/response/WebAdminRideHistoryResponse.java
+++ b/backend/blackcar-web/src/main/java/com/pekara/dto/response/WebAdminRideHistoryResponse.java
@@ -1,0 +1,84 @@
+package com.pekara.dto.response;
+
+import com.pekara.dto.common.WebLocationPoint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Web response DTO for admin ride history list.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WebAdminRideHistoryResponse {
+
+    private Long id;
+    private String status;
+
+    // Dates
+    private LocalDateTime createdAt;
+    private LocalDateTime scheduledAt;
+    private LocalDateTime startedAt;
+    private LocalDateTime completedAt;
+
+    // Locations
+    private String pickupAddress;
+    private String dropoffAddress;
+    private WebLocationPoint pickup;
+    private WebLocationPoint dropoff;
+    private List<WebLocationPoint> stops;
+
+    // Cancellation info
+    private Boolean cancelled;
+    private String cancelledBy;
+    private String cancellationReason;
+    private LocalDateTime cancelledAt;
+
+    // Pricing
+    private BigDecimal price;
+    private Double distanceKm;
+    private Integer estimatedDurationMinutes;
+
+    // Panic info
+    private Boolean panicActivated;
+    private String panickedBy;
+
+    // Vehicle info
+    private String vehicleType;
+    private Boolean babyTransport;
+    private Boolean petTransport;
+
+    // Participants
+    private DriverBasicInfo driver;
+    private List<PassengerBasicInfo> passengers;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DriverBasicInfo {
+        private Long id;
+        private String firstName;
+        private String lastName;
+        private String email;
+        private String phoneNumber;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PassengerBasicInfo {
+        private Long id;
+        private String firstName;
+        private String lastName;
+        private String email;
+    }
+}

--- a/backend/blackcar-web/src/main/java/com/pekara/mapper/RideMapper.java
+++ b/backend/blackcar-web/src/main/java/com/pekara/mapper/RideMapper.java
@@ -14,10 +14,14 @@ import com.pekara.dto.request.WebRideLocationUpdateRequest;
 import com.pekara.dto.request.WebRideRatingRequest;
 import com.pekara.dto.request.WebStopRideEarlyRequest;
 import com.pekara.dto.response.ActiveRideResponse;
+import com.pekara.dto.response.AdminRideDetailResponse;
+import com.pekara.dto.response.AdminRideHistoryResponse;
 import com.pekara.dto.response.DriverRideHistoryResponse;
 import com.pekara.dto.response.PassengerRideHistoryResponse;
 import com.pekara.dto.response.RideTrackingResponse;
 import com.pekara.dto.response.WebActiveRideResponse;
+import com.pekara.dto.response.WebAdminRideDetailResponse;
+import com.pekara.dto.response.WebAdminRideHistoryResponse;
 import com.pekara.dto.response.WebDriverRideHistoryResponse;
 import com.pekara.dto.response.WebPassengerRideHistoryResponse;
 import com.pekara.dto.response.WebRideTrackingResponse;
@@ -262,6 +266,173 @@ public class RideMapper {
                 .vehicleRating(web.getVehicleRating())
                 .driverRating(web.getDriverRating())
                 .comment(web.getComment())
+                .build();
+    }
+
+    // Admin ride history mapping
+    public WebAdminRideHistoryResponse toWebAdminRideHistoryResponse(AdminRideHistoryResponse response) {
+        if (response == null) {
+            return null;
+        }
+
+        return WebAdminRideHistoryResponse.builder()
+                .id(response.getId())
+                .status(response.getStatus())
+                .createdAt(response.getCreatedAt())
+                .scheduledAt(response.getScheduledAt())
+                .startedAt(response.getStartedAt())
+                .completedAt(response.getCompletedAt())
+                .pickupAddress(response.getPickupAddress())
+                .dropoffAddress(response.getDropoffAddress())
+                .pickup(toWebLocation(response.getPickup()))
+                .dropoff(toWebLocation(response.getDropoff()))
+                .stops(response.getStops() == null ? null :
+                        response.getStops().stream().map(this::toWebLocation).collect(Collectors.toList()))
+                .cancelled(response.getCancelled())
+                .cancelledBy(response.getCancelledBy())
+                .cancellationReason(response.getCancellationReason())
+                .cancelledAt(response.getCancelledAt())
+                .price(response.getPrice())
+                .distanceKm(response.getDistanceKm())
+                .estimatedDurationMinutes(response.getEstimatedDurationMinutes())
+                .panicActivated(response.getPanicActivated())
+                .panickedBy(response.getPanickedBy())
+                .vehicleType(response.getVehicleType())
+                .babyTransport(response.getBabyTransport())
+                .petTransport(response.getPetTransport())
+                .driver(mapAdminDriverBasicInfo(response.getDriver()))
+                .passengers(response.getPassengers() == null ? null :
+                        response.getPassengers().stream().map(this::mapAdminPassengerBasicInfo).collect(Collectors.toList()))
+                .build();
+    }
+
+    private WebAdminRideHistoryResponse.DriverBasicInfo mapAdminDriverBasicInfo(AdminRideHistoryResponse.DriverBasicInfo driver) {
+        if (driver == null) {
+            return null;
+        }
+        return WebAdminRideHistoryResponse.DriverBasicInfo.builder()
+                .id(driver.getId())
+                .firstName(driver.getFirstName())
+                .lastName(driver.getLastName())
+                .email(driver.getEmail())
+                .phoneNumber(driver.getPhoneNumber())
+                .build();
+    }
+
+    private WebAdminRideHistoryResponse.PassengerBasicInfo mapAdminPassengerBasicInfo(AdminRideHistoryResponse.PassengerBasicInfo passenger) {
+        if (passenger == null) {
+            return null;
+        }
+        return WebAdminRideHistoryResponse.PassengerBasicInfo.builder()
+                .id(passenger.getId())
+                .firstName(passenger.getFirstName())
+                .lastName(passenger.getLastName())
+                .email(passenger.getEmail())
+                .build();
+    }
+
+    // Admin ride detail mapping
+    public WebAdminRideDetailResponse toWebAdminRideDetailResponse(AdminRideDetailResponse response) {
+        if (response == null) {
+            return null;
+        }
+
+        return WebAdminRideDetailResponse.builder()
+                .id(response.getId())
+                .status(response.getStatus())
+                .createdAt(response.getCreatedAt())
+                .scheduledAt(response.getScheduledAt())
+                .startedAt(response.getStartedAt())
+                .completedAt(response.getCompletedAt())
+                .pickupAddress(response.getPickupAddress())
+                .dropoffAddress(response.getDropoffAddress())
+                .pickup(toWebLocation(response.getPickup()))
+                .dropoff(toWebLocation(response.getDropoff()))
+                .stops(response.getStops() == null ? null :
+                        response.getStops().stream().map(this::toWebLocation).collect(Collectors.toList()))
+                .routeCoordinates(response.getRouteCoordinates())
+                .cancelled(response.getCancelled())
+                .cancelledBy(response.getCancelledBy())
+                .cancellationReason(response.getCancellationReason())
+                .cancelledAt(response.getCancelledAt())
+                .price(response.getPrice())
+                .distanceKm(response.getDistanceKm())
+                .estimatedDurationMinutes(response.getEstimatedDurationMinutes())
+                .panicActivated(response.getPanicActivated())
+                .panickedBy(response.getPanickedBy())
+                .vehicleType(response.getVehicleType())
+                .babyTransport(response.getBabyTransport())
+                .petTransport(response.getPetTransport())
+                .driver(mapAdminDriverDetailInfo(response.getDriver()))
+                .passengers(response.getPassengers() == null ? null :
+                        response.getPassengers().stream().map(this::mapAdminPassengerDetailInfo).collect(Collectors.toList()))
+                .ratings(response.getRatings() == null ? null :
+                        response.getRatings().stream().map(this::mapAdminRideRatingInfo).collect(Collectors.toList()))
+                .inconsistencyReports(response.getInconsistencyReports() == null ? null :
+                        response.getInconsistencyReports().stream().map(this::mapAdminInconsistencyReportInfo).collect(Collectors.toList()))
+                .build();
+    }
+
+    private WebAdminRideDetailResponse.DriverDetailInfo mapAdminDriverDetailInfo(AdminRideDetailResponse.DriverDetailInfo driver) {
+        if (driver == null) {
+            return null;
+        }
+        return WebAdminRideDetailResponse.DriverDetailInfo.builder()
+                .id(driver.getId())
+                .firstName(driver.getFirstName())
+                .lastName(driver.getLastName())
+                .email(driver.getEmail())
+                .phoneNumber(driver.getPhoneNumber())
+                .profilePicture(driver.getProfilePicture())
+                .licenseNumber(driver.getLicenseNumber())
+                .vehicleModel(driver.getVehicleModel())
+                .licensePlate(driver.getLicensePlate())
+                .averageRating(driver.getAverageRating())
+                .totalRides(driver.getTotalRides())
+                .build();
+    }
+
+    private WebAdminRideDetailResponse.PassengerDetailInfo mapAdminPassengerDetailInfo(AdminRideDetailResponse.PassengerDetailInfo passenger) {
+        if (passenger == null) {
+            return null;
+        }
+        return WebAdminRideDetailResponse.PassengerDetailInfo.builder()
+                .id(passenger.getId())
+                .firstName(passenger.getFirstName())
+                .lastName(passenger.getLastName())
+                .email(passenger.getEmail())
+                .phoneNumber(passenger.getPhoneNumber())
+                .profilePicture(passenger.getProfilePicture())
+                .totalRides(passenger.getTotalRides())
+                .averageRating(passenger.getAverageRating())
+                .build();
+    }
+
+    private WebAdminRideDetailResponse.RideRatingInfo mapAdminRideRatingInfo(AdminRideDetailResponse.RideRatingInfo rating) {
+        if (rating == null) {
+            return null;
+        }
+        return WebAdminRideDetailResponse.RideRatingInfo.builder()
+                .id(rating.getId())
+                .passengerId(rating.getPassengerId())
+                .passengerName(rating.getPassengerName())
+                .vehicleRating(rating.getVehicleRating())
+                .driverRating(rating.getDriverRating())
+                .comment(rating.getComment())
+                .ratedAt(rating.getRatedAt())
+                .build();
+    }
+
+    private WebAdminRideDetailResponse.InconsistencyReportInfo mapAdminInconsistencyReportInfo(AdminRideDetailResponse.InconsistencyReportInfo report) {
+        if (report == null) {
+            return null;
+        }
+        return WebAdminRideDetailResponse.InconsistencyReportInfo.builder()
+                .id(report.getId())
+                .reportedByUserId(report.getReportedByUserId())
+                .reportedByName(report.getReportedByName())
+                .description(report.getDescription())
+                .reportedAt(report.getReportedAt())
                 .build();
     }
 }


### PR DESCRIPTION
- Implement `AdminService` and `AdminServiceImpl` for admin ride data management.
- Add DTOs for admin ride detail and history responses.
- Create endpoints for admin all rides history and individual ride details.
- Develop mapping logic for detailed and history responses with enriched data.
- Add repository methods for fetching ride ratings and inconsistency reports.